### PR TITLE
Wire MCP server through orchestrator HTTP port

### DIFF
--- a/.claude/skills/eigenius.md
+++ b/.claude/skills/eigenius.md
@@ -1,0 +1,130 @@
+---
+name: eigenius
+description: Drive the Eigenius typed knowledge graph platform — load Eigon-JSON / ESL resources, run EigenQL queries, execute typed programs (incl. LLM-backed via CompleteText / CompleteJson), inspect chain state and provenance, dispatch D14 institutions (Julia / Lean / WASM). TRIGGER when the user mentions Eigenius, the kernel, ESL, EigenQL, Eigon-JSON, FormulaTerm, ontologies, layers, branches, institutions, verdicts, or asks to load / query / inspect / run something on the platform. Requires the MCP server `eigenius` to be configured.
+---
+
+# Eigenius
+
+Eigenius is a typed knowledge graph platform with verifiable reasoning. Everything is a **Resource** identified by an IRI; resources commit into immutable **layers** that form a chain. Branches optional. Four epistemic categories: *declared*, *observed*, *derived*, *verified* (the last via Lean 4 proofs).
+
+Three surface languages:
+- **Eigon-JSON** — canonical wire format. Property keys are full IRIs. Reserved key: `@id`.
+- **ESL** — human surface that compiles to Eigon-JSON. HCL-style declarations + ML-style expressions.
+- **EigenQL** — typed stratified Datalog over the chain (MATCH / DEFINE / RETURN / FIBER).
+
+## MCP tool surface (14 tools)
+
+Use these via `mcp__eigenius__<tool>`.
+
+| Tool | When to use |
+|------|-------------|
+| `eigenius_health` | Smoke-check before destructive operations |
+| `eigenius_query` | Read state via EigenQL — preferred for "show me X" |
+| `eigenius_inspect` | Get one resource by IRI |
+| `eigenius_load` | Write Eigon-JSON to the chain (commits a new layer) |
+| `eigenius_validate_program` | Type-check a program before running |
+| `eigenius_run_program` | Execute program + input (both inline JSON) |
+| `eigenius_run_program_by_iri` | Execute a program already loaded in the chain |
+| `eigenius_list_institutions` | Discover D14 institutions, QueryClasses, comorphisms |
+| `eigenius_get_schema` | JSON Schema for a class — feed to LLM JSON-mode |
+| `eigenius_list_branches` | Chain navigation: branches |
+| `eigenius_list_tags` | Chain navigation: tags |
+| `eigenius_list_tasks` | Observe long-running programs (D21) |
+| `eigenius_get_task_status` | Detail on one task UUID |
+| `eigenius_layer_topology` | Orient — graph of classes / properties / institutions per layer |
+
+## Vocabulary
+
+- **IRI** — `urn:eigenius:<namespace>:<name>`. Always full in Eigon-JSON; never short.
+- **Layer** — immutable commit, content-addressed by SHA-256 over CBOR; identified by `layer_id` (hex).
+- **Branch** — named pointer to a layer head. Default: `main`.
+- **`is_a`** — every resource declares its classes via `urn:eigenius:core:is_a` (array of class IRIs).
+- **Institution** — D14 reasoning system (Julia / Lean / WASM / in-process Rust).
+- **InductiveType** — chain-resident inductives Mini-TT can `Case`-split on. Distinct from `Class` (the ontology-level shape). A few are dual-declared as both (e.g. `Verdict`) when both shapes are needed. Currently loaded: `core:Option`, `formulas:FormulaTerm`, `lean:LeanExpr` / `LeanLevel` / `LeanLevelList` / `LeanName`, `institution:Verdict`.
+- **`FormulaTerm`** — `urn:eigenius:formulas:FormulaTerm`. Chain-mirrored Mini-TT fragment shared by every numerical institution.
+- **Verdict** — `Holds` / `Fails` / `Undecidable`. The chain-resident outcome of an AutoOnLoad or Decidable QueryClass dispatch.
+- **AutoOnLoad** — institution gate fired automatically on commit when a resource of the bound class enters the chain.
+- **FIBER** — EigenQL clause that dispatches to an institution. `FIBER … AS ?var INTO "<iri>"` commits the response as a chain-resident resource.
+
+## Minimal shapes
+
+Eigon-JSON resource (loaded via `eigenius_load`):
+```json
+{
+  "@id": "urn:eigenius:demo:rex",
+  "urn:eigenius:core:is_a": ["urn:eigenius:demo:Dog"],
+  "urn:eigenius:demo:name": "Rex"
+}
+```
+
+ESL (compiles to the above; the kernel accepts `.esl` directly via `content_type: "application/esl"`):
+```esl
+namespace demo = "urn:eigenius:demo";
+resource demo:rex : demo:Dog { demo:name = "Rex"; }
+```
+
+EigenQL:
+```
+USING "urn:eigenius:demo:Dog"
+MATCH "urn:eigenius:demo:Dog"(?d) { "urn:eigenius:demo:name": ?name }
+RETURN [] { name: ?name }
+```
+
+## Workflow recipes
+
+**Load and query:**
+1. `eigenius_load` with the JSON-stringified Eigon-JSON array (must include `is_a`).
+2. `eigenius_query` with EigenQL referencing the loaded class.
+3. Decode rows from the returned JSON — keys are synthesized IRIs, see pitfalls.
+
+**Run a program:**
+1. `eigenius_validate_program` first (cheap; surfaces type errors without committing).
+2. `eigenius_run_program` (or `_by_iri` if both program and input are already in the chain).
+3. Inspect provenance via `eigenius_inspect` on the returned `trace_iri`.
+
+**Discover and use an institution:**
+1. `eigenius_list_institutions` — surfaces each institution's QueryClasses + comorphisms.
+2. Pick an OnDemand QueryClass; use its `query_class` (input class) and `result_class`.
+3. In EigenQL: `FIBER <institution_iri>(<input>) AS ?out INTO "<output_iri>"`.
+
+**Generate structured LLM output:**
+1. `eigenius_get_schema` for the target class.
+2. Pass the JSON Schema to your LLM's JSON-mode (or use the platform's `CompleteJson` component if running a program).
+
+## Pitfalls
+
+- **`is_a` is mandatory.** The validator rejects resources without a class. The current parser does accept empty arrays as a value shape but the structural validator still requires `is_a` to be non-empty and to resolve.
+- **Query result row keys are synthesized IRIs**, not the short names declared in `RETURN`. Expect keys like `urn:eigenius:query:gen:<hex>:row:<name>`. Match by position or fetch the row class via `eigenius_inspect` to recover short names.
+- **`eigenius_load` takes a JSON *string*** — the proto field is bytes. If constructing programmatically, `JSON.stringify` first.
+- **Branch / tag / task / GC operations need a persistent backend.** In-memory kernels (no `--db`) reject them with `failed_precondition`. Use the docker compose stack or `eigenius serve --db <path>`.
+- **`eigenius_run_program` requires program and input to share content type.** Use `eigenius_run_program_by_iri` when both are already loaded — sidesteps the issue.
+- **D41 commit pipeline returns up to three layers per load.** The top-level `layer_id` always points at the *user* layer, but `committedLayers` may also include an audit-provenance sibling and an institution-classes child. Match on `role`, not array position.
+- **Cascade tombstones (D41).** With `policy: "cascadeTombstone"`, lower-layer IRIs invalidated by the new commit get tombstoned iteratively. Surface this to the user — silent cascades can be surprising.
+
+## Prerequisites
+
+The MCP server `eigenius` must be configured (`claude mcp list` should show it as connected) and the orchestrator (`http://localhost:8080/mcp`) must be reachable. The orchestrator in turn needs the kernel running on `localhost:50051`. The simplest setup:
+
+```bash
+EIGENIUS_MOCK_LLM=true docker compose up -d   # kernel + orchestrator + MCP route
+```
+
+For real LLM responses, set `ANTHROPIC_API_KEY` instead of the mock flag.
+
+## Going deeper
+
+**Guides** (worked examples, chapter-by-chapter):
+- ESL — [https://eigenius.github.io/eigenius/esl/](https://eigenius.github.io/eigenius/esl/)
+- EigenQL — [https://eigenius.github.io/eigenius/eigenql/](https://eigenius.github.io/eigenius/eigenql/)
+- Formula language — [https://eigenius.github.io/eigenius/formula/](https://eigenius.github.io/eigenius/formula/)
+- Platform (notebook, CLI, deployment, runtime substrate, Julia / Lean walkthroughs, SDK) — [https://eigenius.github.io/eigenius/platform/](https://eigenius.github.io/eigenius/platform/)
+- References / bibliography — [https://eigenius.github.io/eigenius/references/](https://eigenius.github.io/eigenius/references/)
+
+**Design documents** (specs; in-repo only):
+- Index — [docs/design/](https://github.com/eigenius/eigenius/tree/main/docs/design)
+- [D1](https://github.com/eigenius/eigenius/blob/main/docs/design/d1-eigon-serialization-format.md) Eigon serialization · [D2](https://github.com/eigenius/eigenius/blob/main/docs/design/d2-eigenql-specification.md) EigenQL · [D3](https://github.com/eigenius/eigenius/blob/main/docs/design/d3-program-model.md) Program model · [D7](https://github.com/eigenius/eigenius/blob/main/docs/design/d7-esl-surface-syntax.md) ESL syntax
+- [D14](https://github.com/eigenius/eigenius/blob/main/docs/design/d14-institution-realisation.md) Institution realisation · [D22](https://github.com/eigenius/eigenius/blob/main/docs/design/d22-notebook-and-typescript-sdk.md) Notebook + SDK · [D41](https://github.com/eigenius/eigenius/blob/main/docs/design/d41-commit-pipeline.md) Commit pipeline
+- [D26](https://github.com/eigenius/eigenius/blob/main/docs/design/d26-runtime-substrate.md) Runtime substrate · [D27](https://github.com/eigenius/eigenius/blob/main/docs/design/d27-julia-institutions.md) Julia institutions · [D28](https://github.com/eigenius/eigenius/blob/main/docs/design/d28-lean-4-as-institution.md) Lean verification
+
+**Source of truth for the bootstrap ontologies** (always read these rather than memorize):
+- `ontologies/core/` `ontologies/program/` `ontologies/reflection/` `ontologies/institution/` `ontologies/formulas/` `ontologies/runtime/`

--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ open http://localhost:8080/notebooks/   # macOS; xdg-open on Linux
 
 # Run the end-to-end CLI demo
 ./demo/run.sh
+
+# Drive the platform from an LLM agent (Claude Code / Desktop / Cursor / ...)
+claude mcp add --transport http eigenius http://localhost:8080/mcp
 ```
 
-The first build takes a few minutes (Rust + WASM components). Subsequent ups are fast. See [Docker Compose](#docker-compose) below for state inspection, logs, and `ANTHROPIC_API_KEY` setup, or [Getting Started](#getting-started) for a native-toolchain build.
+The first build takes a few minutes (Rust + WASM components). Subsequent ups are fast. See [Docker Compose](#docker-compose) below for state inspection, logs, and `ANTHROPIC_API_KEY` setup, [MCP server](#mcp-server-for-llm-agents) for the agent surface, or [Getting Started](#getting-started) for a native-toolchain build.
 
 **What Eigenius gives you, today:**
 
@@ -106,7 +109,7 @@ The system can:
 - Dispatch IO components to the Deno orchestrator via gRPC (ComponentExecutor service)
 - Call LLMs via Vercel AI SDK (Anthropic) with prompt templating and metrics
 - Generate structured LLM output via CompleteJson (JSON Schema from ontology classes)
-- Expose kernel operations as MCP tools for LLM agents
+- Expose 14 kernel operations as MCP tools (query / inspect / load / run-program / institutions / schema / branches / tags / tasks / topology / health) for LLM agents. HTTP transport at `http://localhost:8080/mcp` when the docker stack is up (point Claude Desktop / Claude Code at the URL); stdio also available via `cd orchestration && deno task mcp` for kernel-on-host development
 - Track four epistemic categories: declared, observed, derived, verified
 - Record tree-structured reasoning traces with memoization and incremental execution
 - Validate epistemic base class requirements (DeclaredResource, DerivedResource, etc.)
@@ -265,6 +268,93 @@ block in `docker-compose.yml`:
 `eigenius_kernel=debug` turns on per-RPC and per-chain-walk events; `info`
 keeps the rest of the workspace at the default level. `trace` is rarely
 useful — that's where high-volume per-resource events live.
+
+## MCP server (for LLM agents)
+
+The orchestrator exposes a curated subset of the kernel surface as
+[Model Context Protocol](https://modelcontextprotocol.io) tools, so an LLM
+agent can drive Eigenius as part of its reasoning — query the graph, run
+programs, inspect provenance, discover institutions.
+
+**14 tools** are wired across three groups:
+
+| Group | Tools |
+|---|---|
+| Explore | `eigenius_query`, `eigenius_inspect`, `eigenius_list_branches`, `eigenius_list_tags`, `eigenius_list_institutions`, `eigenius_get_schema`, `eigenius_layer_topology` |
+| Mutate  | `eigenius_load` (with D41 `policy` / `explicitTombstones`), `eigenius_validate_program`, `eigenius_run_program`, `eigenius_run_program_by_iri` |
+| Observe | `eigenius_health`, `eigenius_list_tasks`, `eigenius_get_task_status` |
+
+Branch / tag mutation, merge submission, consolidation, GC, and task
+cancellation are deliberately **not** exposed — those are stateful or
+destructive flows that belong to the notebook UI or the operator CLI.
+
+### Setup
+
+The orchestrator mounts MCP at `http://localhost:8080/mcp` (Streamable
+HTTP, stateless + JSON-response mode). With the docker stack up, point any
+MCP-aware client at that URL.
+
+**Claude Code** (CLI or VS Code extension):
+
+```bash
+claude mcp add --transport http eigenius http://localhost:8080/mcp
+claude mcp list                                     # verify ✓ Connected
+```
+
+**Claude Desktop / Cursor / IDE agents** — edit the host's MCP config and
+add an `eigenius` entry:
+
+```json
+{
+  "mcpServers": {
+    "eigenius": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+Config file locations:
+
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+
+For a **stdio** transport (kernel-on-host development, no orchestrator
+container required), run `cd orchestration && deno task mcp` and point
+the client at that subprocess. See
+[platform guide §7.7](docs/guides/platform/07-orchestrator.md#77-the-mcp-server)
+for the full client wiring.
+
+### The `eigenius` skill (Claude Code only)
+
+The repo ships an agent skill at
+[`.claude/skills/eigenius.md`](.claude/skills/eigenius.md) — a project-scoped
+file Claude Code loads automatically when you launch it from the repo root.
+The skill teaches Claude the platform's mental model, the three surface
+languages, the MCP tool selection table, minimal Eigon-JSON / ESL / EigenQL
+shapes, common workflows, and the pitfalls that trip agents up (mandatory
+`is_a`, synthesized IRI row keys in query results, persistent-backend
+requirements, D41 multi-layer outcomes, …).
+
+After `claude mcp add` and a fresh Claude Code session, ask the agent
+something like *"check the eigenius health"* or *"list the classes loaded in
+eigenius"* — the skill auto-triggers on platform keywords and the agent
+picks the right tool. Or invoke explicitly via `/eigenius`.
+
+To use the skill across all your projects, copy it to
+`~/.claude/skills/eigenius.md`.
+
+### Smoke-test with the MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector --url http://localhost:8080/mcp
+```
+
+Opens a web UI for poking at the tools interactively. If
+`eigenius_health` returns `{ healthy: true, ... }`, the whole chain
+(client → orchestrator → kernel) is good.
 
 ## Repository Structure
 

--- a/docs/guides/platform/07-orchestrator.md
+++ b/docs/guides/platform/07-orchestrator.md
@@ -119,19 +119,135 @@ When the kernel dispatches a component, the orchestrator's RPC server (`/dispatc
 
 ## 7.7. The MCP server
 
-The orchestrator exposes Eigenius operations as MCP tools so external LLM agents (Claude Desktop, Cursor, etc.) can query the graph and run programs as part of their reasoning.
+The orchestrator exposes a curated subset of the kernel surface as [Model Context Protocol](https://modelcontextprotocol.io) tools so LLM agents (Claude Code, Claude Desktop, Cursor, IDE agents) can drive Eigenius as part of their reasoning.
 
-Source: [`orchestration/src/mcp/server.ts`](../../../orchestration/src/mcp/server.ts).
+Two transports are wired:
 
-Tools currently exposed:
+- **HTTP** — `http://localhost:8080/mcp` on the orchestrator's existing port, mounted alongside the notebook SPA and Connect RPC. This is the right path for `docker compose up` workflows — the agent client connects directly without a host-side subprocess.
+- **stdio** — `cd orchestration && deno task mcp` runs a standalone process that talks MCP over stdin/stdout against an already-running kernel. Useful when you want a kernel on the host (e.g., `eigenius serve --port 50051`) without bringing up the orchestrator container.
 
-- **`eigenius_query`** — execute an EigenQL query against the kernel
-- **`eigenius_inspect`** — fetch a resource by IRI
-- **`eigenius_load`** — load an Eigon-JSON or ESL file
-- **`eigenius_run`** — execute a typed program
-- **`eigenius_list_institutions`** — list registered institutions
+Source: [`orchestration/src/mcp/server.ts`](../../../orchestration/src/mcp/server.ts) (tools), [`orchestration/src/mcp/http.ts`](../../../orchestration/src/mcp/http.ts) (HTTP transport), [`orchestration/src/mcp_main.ts`](../../../orchestration/src/mcp_main.ts) (stdio entry point).
 
-Connect a tool-using LLM by pointing its MCP client at `http://localhost:8080/mcp`. The exact configuration depends on the client; see the MCP specification at [modelcontextprotocol.io](https://modelcontextprotocol.io).
+### 7.7.1. The tool surface (14 tools)
+
+Each tool wraps one or two kernel RPCs and surfaces the response as JSON. Categories follow the platform's natural division:
+
+**Explore (read-only chain navigation):**
+
+- `eigenius_query` — execute an EigenQL query; rows decoded from Eigon-CBOR to JSON
+- `eigenius_inspect` — resolve a single resource by IRI
+- `eigenius_list_branches` — branches with head LayerId + commit time
+- `eigenius_list_tags` — immutable tag refs
+- `eigenius_list_institutions` — D14 institutions with their QueryClasses + comorphisms + runtime kind
+- `eigenius_get_schema` — JSON Schema for an ontology class, derived from the chain
+- `eigenius_layer_topology` — graph (nodes + edges) of classes / properties / institutions per layer
+
+**Mutate (commit-shaped operations):**
+
+- `eigenius_load` — load Eigon-JSON; supports `policy: "reject" | "cascadeTombstone"`, `branch`, `explicitTombstones` (D41)
+- `eigenius_validate_program` — type-check a program without executing
+- `eigenius_run_program` — execute program + input (both inline as Eigon-JSON)
+- `eigenius_run_program_by_iri` — execute a program already loaded in the chain
+
+**Observe (state and tasks):**
+
+- `eigenius_health` — kernel version, layer count, resource count, D21 resume-sweep state
+- `eigenius_list_tasks` — D21 tasks (running, suspended, completed, failed)
+- `eigenius_get_task_status` — detail for one task UUID
+
+**Out of scope (deliberately).** Branch / tag mutation, merge submission, chain consolidation, GC, task cancellation. These are stateful multi-turn flows or destructive operations — they belong in the notebook UI or operator CLI, not in a single-turn agent invocation. Use the [CLI](04-cli-reference.md) or the [notebook workspace rail](14-notebook.md) for those.
+
+### 7.7.2. Setup — Docker Compose path (recommended)
+
+Bring the stack up:
+
+```bash
+EIGENIUS_MOCK_LLM=true docker compose up -d
+# kernel on :50051, orchestrator on :8080 (notebook + /mcp + RPC)
+```
+
+Then register the MCP server with your client of choice. For [**Claude Code**](https://claude.com/claude-code) (CLI or VS Code extension):
+
+```bash
+claude mcp add --transport http eigenius http://localhost:8080/mcp
+claude mcp list                            # verify it shows ✓ Connected
+```
+
+For **Claude Desktop**, edit `claude_desktop_config.json` (`%APPDATA%\Claude\` on Windows, `~/Library/Application Support/Claude/` on macOS, `~/.config/Claude/` on Linux):
+
+```json
+{
+  "mcpServers": {
+    "eigenius": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+Restart the app. The 14 `eigenius_*` tools appear in the tool list.
+
+### 7.7.3. Setup — stdio path (kernel-on-host development)
+
+When you want a kernel running on your host (faster iteration, no rebuild for kernel changes) but don't want to bring up the orchestrator container, use stdio. Start the kernel directly:
+
+```bash
+eigenius serve --port 50051 --db /var/lib/eigenius/db
+```
+
+Then configure your client to launch the MCP stdio entry point on demand. Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "eigenius": {
+      "command": "deno",
+      "args": ["task", "mcp"],
+      "cwd": "/absolute/path/to/eigenius/orchestration",
+      "env": { "EIGENIUS_KERNEL_ENDPOINT": "http://localhost:50051" }
+    }
+  }
+}
+```
+
+`deno task mcp` is defined in [`orchestration/deno.json`](../../../orchestration/deno.json) and runs [`src/mcp_main.ts`](../../../orchestration/src/mcp_main.ts). The orchestrator container does **not** need to be running for this path.
+
+### 7.7.4. The `eigenius` skill (Claude Code)
+
+The repo ships an agent skill at [`.claude/skills/eigenius.md`](../../../.claude/skills/eigenius.md) that teaches Claude Code how to use the platform correctly: the mental model, the three surface languages, the MCP tool selection table, minimal Eigon-JSON / ESL / EigenQL shapes, common workflows, and the pitfalls that trip agents up (mandatory `is_a`, synthesized IRI row keys in query results, persistent-backend requirements, D41 multi-layer outcomes, …).
+
+The skill is **project-scoped** — every developer who clones the repo and runs Claude Code from the project root picks it up automatically. To use it across projects, copy to `~/.claude/skills/eigenius.md`.
+
+Skills are discovered at session startup. After cloning the repo, start a fresh Claude Code session — the skill auto-triggers whenever the user mentions *Eigenius*, *kernel*, *ESL*, *EigenQL*, *Eigon-JSON*, *layer*, *branch*, *institution*, *Verdict*, or asks to load / query / inspect / run something. Explicit invocation also works via `/eigenius`.
+
+### 7.7.5. Smoke-test with the MCP Inspector
+
+Before wiring into a client, confirm the server works against the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector --url http://localhost:8080/mcp
+```
+
+Opens a local web UI where you can list tools and invoke them interactively. If `eigenius_health` returns `{ healthy: true, version: "...", ... }`, the orchestrator → kernel path is good.
+
+### 7.7.6. Debugging
+
+If a client says "MCP server failed to connect," walk the chain bottom-up:
+
+1. **Kernel reachable?** — `curl http://localhost:50051/` (gRPC will reject the bare GET but the connection should establish; "connection refused" means the kernel isn't running).
+2. **Orchestrator reachable?** — `curl http://localhost:8080/health` should return `{"healthy":true,...}`.
+3. **MCP endpoint live?** — `curl -X POST http://localhost:8080/mcp -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'` should return a JSON-RPC response with `serverInfo.name === "eigenius"`.
+4. **Client wiring** — `claude mcp list` (Claude Code) or check `~/Library/Logs/Claude/mcp.log` / `%APPDATA%\Claude\Logs\mcp.log` (Claude Desktop) for handshake errors.
+
+The orchestrator logs each MCP request to stderr; pipe it through `jq` when running against a real client to see what the agent is calling.
+
+### 7.7.7. Architecture and scope notes
+
+- **Mode:** stateless + JSON-response. `WebStandardStreamableHTTPServerTransport` from the SDK with `sessionIdGenerator: undefined` and `enableJsonResponse: true`. Each POST is one tool invocation, one JSON-RPC response. No SSE streaming, no session bookkeeping.
+- **Per-request lifecycle:** the SDK requires a fresh `McpServer` + `Transport` pair per request in stateless mode; the orchestrator's HTTP handler builds them on demand and tears them down when the response resolves. The underlying `KernelClient` (Connect RPC over gRPC-Web) is long-lived.
+- **CORS:** not configured. Native MCP clients don't need it; if you want a browser-based agent to call MCP from a different origin, add CORS headers to the `/mcp` branch in [`orchestration/src/server/mod.ts`](../../../orchestration/src/server/mod.ts).
+- **Authentication:** none. The current model assumes the orchestrator port is reachable only to trusted callers (local docker stack, dev environment). Production deployment should front the orchestrator with a proxy that enforces auth before forwarding to `/mcp`.
 
 ## 7.8. WASM IO components
 

--- a/orchestration/deno.json
+++ b/orchestration/deno.json
@@ -5,6 +5,7 @@
   "tasks": {
     "dev": "deno run --watch --allow-net --allow-read --allow-ffi --allow-env --allow-sys --unstable-node-globals --unstable-detect-cjs src/main.ts",
     "start": "deno run --allow-net --allow-read --allow-ffi --allow-env --allow-sys --unstable-node-globals --unstable-detect-cjs src/main.ts",
+    "mcp": "deno run --allow-net --allow-read --allow-env --unstable-node-globals --unstable-detect-cjs src/mcp_main.ts",
     "test": "deno test --allow-net --allow-read --allow-ffi --allow-env --allow-sys --allow-run --unstable-node-globals --unstable-detect-cjs tests/",
     "build:addon": "cd native && npm install --silent && ./node_modules/.bin/napi build --platform --release",
     "build:substrate-addon": "cd runtime-substrate-native && npm install --silent && ./node_modules/.bin/napi build --platform --release",

--- a/orchestration/deno.lock
+++ b/orchestration/deno.lock
@@ -12,6 +12,7 @@
     "npm:@connectrpc/connect-node@2": "2.1.1_@bufbuild+protobuf@2.11.0_@connectrpc+connect@2.1.1__@bufbuild+protobuf@2.11.0",
     "npm:@connectrpc/connect-web@2": "2.1.1_@bufbuild+protobuf@2.11.0_@connectrpc+connect@2.1.1__@bufbuild+protobuf@2.11.0",
     "npm:@connectrpc/connect@2": "2.1.1_@bufbuild+protobuf@2.11.0",
+    "npm:@modelcontextprotocol/sdk@*": "1.29.0_zod@3.25.76",
     "npm:@modelcontextprotocol/sdk@latest": "1.29.0_zod@3.25.76",
     "npm:ai@latest": "6.0.158_zod@3.25.76",
     "npm:cbor-x@1": "1.6.4",

--- a/orchestration/src/main.ts
+++ b/orchestration/src/main.ts
@@ -50,6 +50,8 @@ import {
   CALL_RUNTIME_METHOD_IRI,
   createCallRuntimeMethodHandler,
 } from "./components/call_runtime_method.ts";
+import { createMcpServer } from "./mcp/server.ts";
+import { createMcpHttpHandler } from "./mcp/http.ts";
 
 const KERNEL_ENDPOINT = Deno.env.get("EIGENIUS_KERNEL_ENDPOINT") ??
   "http://localhost:50051";
@@ -93,7 +95,7 @@ const LEAN_COMMON_DIR = Deno.env.get("EIGENIUS_LEAN_COMMON_DIR");
 const LEAN_BASE_IMAGE_REF = Deno.env.get("EIGENIUS_LEAN_BASE_IMAGE_REF");
 const LEAN_DEPOT_PATH = Deno.env.get("EIGENIUS_LEAN_DEPOT_PATH");
 
-function main() {
+async function main() {
   // Install the structured-logging subscriber before anything else
   // emits an event. Reads `EIGENIUS_LOG_LEVEL` and
   // `EIGENIUS_LOG_FORMAT` from env (same envelope as the kernel).
@@ -269,7 +271,14 @@ function main() {
     },
   );
 
-  // Start the orchestrator server (gRPC + NotebookService + health).
+  // MCP server — exposes a curated subset of the kernel surface to
+  // LLM agents over the orchestrator's HTTP port (`/mcp`). Stateless
+  // JSON-response mode; see `mcp/http.ts`. The SDK requires a fresh
+  // server + transport pair per request in stateless mode, so we pass
+  // a builder rather than a built instance.
+  const mcpHandler = createMcpHttpHandler(() => createMcpServer(client));
+
+  // Start the orchestrator server (gRPC + NotebookService + health + MCP).
   // Pass the substrate addon explicitly so the `DispatchExternal` RPC
   // (D31 §6.2) can route into the same handle that powers
   // `RunRuntimeScript` / `CallRuntimeMethod`.
@@ -279,7 +288,8 @@ function main() {
     ORCHESTRATOR_PORT,
     wasm,
     substrateAddon ?? undefined,
+    mcpHandler,
   );
 }
 
-main();
+await main();

--- a/orchestration/src/main.ts
+++ b/orchestration/src/main.ts
@@ -95,7 +95,7 @@ const LEAN_COMMON_DIR = Deno.env.get("EIGENIUS_LEAN_COMMON_DIR");
 const LEAN_BASE_IMAGE_REF = Deno.env.get("EIGENIUS_LEAN_BASE_IMAGE_REF");
 const LEAN_DEPOT_PATH = Deno.env.get("EIGENIUS_LEAN_DEPOT_PATH");
 
-async function main() {
+function main() {
   // Install the structured-logging subscriber before anything else
   // emits an event. Reads `EIGENIUS_LOG_LEVEL` and
   // `EIGENIUS_LOG_FORMAT` from env (same envelope as the kernel).
@@ -292,4 +292,4 @@ async function main() {
   );
 }
 
-await main();
+main();

--- a/orchestration/src/mcp/http.ts
+++ b/orchestration/src/mcp/http.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 The Eigenius Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * HTTP transport for the Eigenius MCP server.
+ *
+ * Mounts on the orchestrator's existing HTTP port (`/mcp`) so MCP clients
+ * configured with an HTTP URL — Claude Desktop, Claude Code CLI, IDE
+ * agents — can drive the kernel through the dockerized stack without a
+ * separate stdio subprocess.
+ *
+ * Built on the MCP SDK's `WebStandardStreamableHTTPServerTransport`
+ * (added in SDK 1.25.0). The transport's API is pure Web-standard
+ * (`Request` in, `Response` out), so it slots into `Deno.serve`
+ * directly — no Node-stream shimming.
+ *
+ * Mode: **stateless + JSON-response**. `sessionIdGenerator: undefined`
+ * disables session tracking; `enableJsonResponse: true` returns plain
+ * JSON-RPC responses instead of opening an SSE stream. Our tool
+ * surface is synchronous request-response (every tool invocation
+ * resolves to one MCP `CallToolResult`), so SSE buys nothing.
+ *
+ * Per-request lifecycle: a fresh `McpServer` + `Transport` pair is
+ * constructed for every request, then closed when the request resolves.
+ * The SDK enforces this — stateless transports cannot be reused, since
+ * they keep per-request state to route in-flight responses. See the
+ * SDK's `examples/server/simpleStatelessStreamableHttp.js` for the
+ * canonical Express version of the same pattern.
+ */
+
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as log from "../observability/mod.ts";
+import { operation } from "../observability/mod.ts";
+
+/**
+ * Build an HTTP handler that serves the MCP protocol against MCP server
+ * instances produced by `buildServer`. Caller mounts the returned handler
+ * on a route (typically `/mcp`).
+ *
+ * `buildServer` is invoked per request — the SDK requires a fresh
+ * server + transport for every stateless invocation. The tool registry
+ * itself is reconstructed each call but the work is cheap (no I/O, just
+ * Zod schema + handler closure registration), and the underlying
+ * `KernelClient` / Connect transport is long-lived.
+ */
+export function createMcpHttpHandler(
+  buildServer: () => McpServer,
+): (req: Request) => Promise<Response> {
+  log.info(operation.MCP_SERVER_START, "MCP HTTP handler ready", {
+    transport: "http",
+    mode: "stateless+json",
+  });
+
+  return async (req: Request): Promise<Response> => {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    const server = buildServer();
+    try {
+      await server.connect(transport);
+      return await transport.handleRequest(req);
+    } catch (error) {
+      log.error(operation.MCP_SERVER_START, "MCP request failed", {
+        error_kind: "mcp_request_panic",
+        error_message: error instanceof Error ? error.message : String(error),
+      });
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32603, message: "Internal server error" },
+          id: null,
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    } finally {
+      // The SDK example listens for `res.on('close')` and closes
+      // there; Deno's Web `Response` flow doesn't expose an equivalent
+      // event, but since `handleRequest` resolves once the response is
+      // fully composed, closing eagerly after the await is safe.
+      await transport.close().catch(() => {});
+      await server.close().catch(() => {});
+    }
+  };
+}

--- a/orchestration/src/mcp/server.ts
+++ b/orchestration/src/mcp/server.ts
@@ -120,7 +120,9 @@ export function createMcpServer(client: KernelClient): McpServer {
       if (!resp.success) {
         return errorResult(`Query failed: ${resp.error}`);
       }
-      const rows = resp.document.length > 0 ? decodeQueryRows(resp.document) : [];
+      const rows = resp.document.length > 0
+        ? decodeQueryRows(resp.document)
+        : [];
       return jsonResult({
         rows,
         rowCount: rows.length,
@@ -207,7 +209,9 @@ export function createMcpServer(client: KernelClient): McpServer {
       "required / recommended properties walked through the layer chain. " +
       "Useful for grounding LLM JSON generation in the typed shape.",
     {
-      classIri: z.string().describe("IRI of the class to generate a schema for."),
+      classIri: z.string().describe(
+        "IRI of the class to generate a schema for.",
+      ),
       atLayer: z.string().optional().describe(
         "Hex-encoded LayerId to read against (defaults to the active top).",
       ),

--- a/orchestration/src/mcp/server.ts
+++ b/orchestration/src/mcp/server.ts
@@ -15,172 +15,454 @@
 /**
  * MCP Server — LLM tool-use surface for the Eigenius kernel.
  *
- * Exposes kernel operations as MCP tools that an LLM agent can invoke:
- * - eigenius_query: Execute an EigenQL query
- * - eigenius_inspect: Resolve a resource by IRI
- * - eigenius_load: Load resources into the kernel
- * - eigenius_validate: Validate a program
+ * Exposes a curated subset of the kernel's gRPC RPCs as MCP tools so that
+ * LLM agents (Claude Desktop, IDE-integrated agents, etc.) can drive the
+ * platform — query the knowledge graph, run programs, inspect provenance,
+ * and observe chain state.
  *
- * Transport: SSE/HTTP for remote agents. Stdio also available.
+ * Scope:
+ *   - Explore  — query, inspect, list_branches / tags / institutions,
+ *                get_schema, layer_topology
+ *   - Mutate   — load, validate_program, run_program, run_program_by_iri
+ *   - Observe  — health, list_tasks, get_task_status
  *
- * Architecture reference: §2.3 (AI Integration Model), Phase 4 plan §5
+ * Out of scope (deliberately): branch / tag mutation, merge submission,
+ * GC, consolidation, task cancellation. Those are stateful multi-turn
+ * flows or destructive ops that belong to the notebook UI or an operator,
+ * not a single-turn agent invocation.
+ *
+ * Transport: stdio (via [`startStdioServer`]) is the wired entry point.
+ * See [`../mcp_main.ts`] for the standalone stdio binary. An HTTP
+ * transport mounted on the orchestrator's main port is a tracked
+ * follow-up — the MCP SDK's `StreamableHTTPServerTransport` is built for
+ * Node's `http.ServerResponse`, and adapting that surface to Deno's
+ * `Request` / `Response` needs care to avoid breaking the existing
+ * Connect-RPC handlers on the same port.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import type { KernelClient } from "../client/kernel_client.ts";
+import { create, toJson } from "@bufbuild/protobuf";
+import { decode as cborDecode } from "cbor-x";
+import type { KernelClient, LoadPolicy } from "../client/kernel_client.ts";
+import {
+  GetSchemaRequestSchema,
+  GetSchemaResponseSchema,
+  GetTaskStatusRequestSchema,
+  GetTaskStatusResponseSchema,
+  HealthRequestSchema,
+  HealthResponseSchema,
+  InspectRequestSchema,
+  LayerTopologyRequestSchema,
+  LayerTopologyResponseSchema,
+  ListBranchesRequestSchema,
+  ListBranchesResponseSchema,
+  ListInstitutionsRequestSchema,
+  ListInstitutionsResponseSchema,
+  ListTagsRequestSchema,
+  ListTagsResponseSchema,
+  ListTasksRequestSchema,
+  ListTasksResponseSchema,
+  LoadResponseSchema,
+  QueryRequestSchema,
+  RunProgramByIriRequestSchema,
+  RunProgramResponseSchema,
+  ValidateProgramResponseSchema,
+} from "../gen/eigenius_pb.ts";
 import * as log from "../observability/mod.ts";
 import { operation } from "../observability/mod.ts";
 
+const SERVER_NAME = "eigenius";
+const SERVER_VERSION = "0.2.0";
+
 /**
  * Create and configure the Eigenius MCP server.
+ *
+ * Each tool wraps one (or, in a few cases, one-and-a-half) kernel RPCs.
+ * Responses are returned as a single text content block carrying the
+ * JSON-serialised proto response (enums rendered as their string names
+ * via `toJson`), with `isError: true` set on RPC-level failures.
  */
 export function createMcpServer(client: KernelClient): McpServer {
   const server = new McpServer({
-    name: "eigenius",
-    version: "0.1.0",
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
   });
 
-  // --- eigenius_query ---
+  // ===========================================================================
+  // Explore — read-only navigation of the chain.
+  // ===========================================================================
+
   server.tool(
     "eigenius_query",
-    "Execute an EigenQL query against the Eigenius knowledge graph. Returns matching resources as JSON.",
-    { eigenql: z.string().describe("The EigenQL query string") },
-    async (args: { eigenql: string }) => {
-      try {
-        const results = await client.query(args.eigenql);
-        const decoder = new TextDecoder();
-        const decoded = results.map((r: Uint8Array) => decoder.decode(r));
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(decoded, null, 2),
-          }],
-        };
-      } catch (e) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Query failed: ${(e as Error).message}`,
-          }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // --- eigenius_inspect ---
-  server.tool(
-    "eigenius_inspect",
-    "Resolve a resource by its IRI from the Eigenius knowledge graph. Returns the resource as JSON.",
-    { iri: z.string().describe("The IRI of the resource to inspect") },
-    async (args: { iri: string }) => {
-      try {
-        const response = await client.inspect(args.iri);
-        if (!response.found) {
-          return {
-            content: [{
-              type: "text" as const,
-              text: `Resource not found: ${args.iri}`,
-            }],
-          };
-        }
-        const decoder = new TextDecoder();
-        return {
-          content: [{
-            type: "text" as const,
-            text: decoder.decode(response.resource),
-          }],
-        };
-      } catch (e) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Inspect failed: ${(e as Error).message}`,
-          }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // --- eigenius_load ---
-  server.tool(
-    "eigenius_load",
-    "Load resources into the Eigenius knowledge graph. Resources are provided as Eigon-JSON.",
+    "Execute an EigenQL query against the Eigenius knowledge graph. " +
+      "Returns the rows as decoded JS objects (Eigon-CBOR → JSON), plus " +
+      "any FIBER ... INTO output IRIs and the branch-CAS outcome. Optionally " +
+      "pin reads to a specific branch or layer for time-travel queries.",
     {
-      json: z.string().describe("Eigon-JSON array of resources to load"),
-      auto_commit: z.boolean().optional().describe(
-        "Whether to commit after loading (default: true)",
+      eigenql: z.string().describe(
+        "EigenQL program string. See docs/guides/eigenql/ for the language reference.",
+      ),
+      branch: z.string().optional().describe(
+        "Branch to pin reads to (defaults to 'main').",
+      ),
+      atLayer: z.string().optional().describe(
+        "Hex-encoded LayerId to pin reads to. Mutually exclusive with `branch`.",
       ),
     },
-    async (args: { json: string; auto_commit?: boolean }) => {
-      try {
-        const response = await client.load(
-          args.json,
-          { autoCommit: args.auto_commit ?? true },
-        );
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                success: response.success,
-                resourceCount: response.resourceCount,
-                layerId: response.layerId,
-                errors: response.errors,
-              },
-              null,
-              2,
-            ),
-          }],
-        };
-      } catch (e) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Load failed: ${(e as Error).message}`,
-          }],
-          isError: true,
-        };
+    async (args: { eigenql: string; branch?: string; atLayer?: string }) => {
+      const resp = await client.raw.query(create(QueryRequestSchema, {
+        eigenql: args.eigenql,
+        branch: args.branch ?? "",
+        atLayer: args.atLayer ?? "",
+      }));
+      if (!resp.success) {
+        return errorResult(`Query failed: ${resp.error}`);
       }
+      const rows = resp.document.length > 0 ? decodeQueryRows(resp.document) : [];
+      return jsonResult({
+        rows,
+        rowCount: rows.length,
+        outputResourceIris: resp.outputResourceIris,
+        branchAdvanced: resp.branchAdvanced,
+        merge: resp.merge ? toJsonSafe("MergeInfo", resp.merge) : null,
+      });
     },
   );
 
-  // --- eigenius_validate ---
   server.tool(
-    "eigenius_validate",
-    "Type-check and validate an Eigenius program. Returns validation results.",
+    "eigenius_inspect",
+    "Resolve a single resource by its IRI. Returns the resource decoded " +
+      "from Eigon-CBOR to a JSON object (property keys are full IRIs).",
     {
-      program: z.string().describe("Program resource as Eigon-JSON"),
+      iri: z.string().describe("IRI of the resource to inspect."),
+      branch: z.string().optional().describe(
+        "Branch to read from (defaults to 'main').",
+      ),
+      atLayer: z.string().optional().describe(
+        "Hex-encoded LayerId to pin the read to. Mutually exclusive with `branch`.",
+      ),
     },
-    async (args: { program: string }) => {
-      try {
-        const response = await client.validateProgram(args.program);
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                valid: response.valid,
-                programType: response.programType,
-                errors: response.errors,
-              },
-              null,
-              2,
-            ),
-          }],
-        };
-      } catch (e) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Validate failed: ${(e as Error).message}`,
-          }],
-          isError: true,
-        };
+    async (args: { iri: string; branch?: string; atLayer?: string }) => {
+      const resp = await client.raw.inspect(create(InspectRequestSchema, {
+        iri: args.iri,
+        branch: args.branch ?? "",
+        atLayer: args.atLayer ?? "",
+      }));
+      if (!resp.found) {
+        return jsonResult({ found: false, iri: args.iri });
       }
+      const decoded = cborDecode(resp.resource);
+      return jsonResult({ found: true, iri: args.iri, resource: decoded });
+    },
+  );
+
+  server.tool(
+    "eigenius_list_branches",
+    "List every branch ref with its head LayerId and head commit time.",
+    {},
+    async () => {
+      const resp = await client.raw.listBranches(
+        create(ListBranchesRequestSchema, {}),
+      );
+      return jsonResult(
+        toJson(ListBranchesResponseSchema, resp),
+      );
+    },
+  );
+
+  server.tool(
+    "eigenius_list_tags",
+    "List every immutable tag ref with its target LayerId.",
+    {},
+    async () => {
+      const resp = await client.raw.listTags(create(ListTagsRequestSchema, {}));
+      return jsonResult(toJson(ListTagsResponseSchema, resp));
+    },
+  );
+
+  server.tool(
+    "eigenius_list_institutions",
+    "List indexed D14 institutions with their QueryClasses, comorphisms, " +
+      "runtime kind, and required RuntimeEnvironment (if external). Use " +
+      "this to discover what FIBER queries and AutoOnLoad gates are " +
+      "available on the chain.",
+    {
+      atLayer: z.string().optional().describe(
+        "Hex-encoded LayerId to read against (defaults to the active top).",
+      ),
+    },
+    async (args: { atLayer?: string }) => {
+      const resp = await client.raw.listInstitutions(
+        create(ListInstitutionsRequestSchema, { atLayer: args.atLayer ?? "" }),
+      );
+      return jsonResult(toJson(ListInstitutionsResponseSchema, resp));
+    },
+  );
+
+  server.tool(
+    "eigenius_get_schema",
+    "Generate a JSON Schema for an ontology class, derived from the class's " +
+      "required / recommended properties walked through the layer chain. " +
+      "Useful for grounding LLM JSON generation in the typed shape.",
+    {
+      classIri: z.string().describe("IRI of the class to generate a schema for."),
+      atLayer: z.string().optional().describe(
+        "Hex-encoded LayerId to read against (defaults to the active top).",
+      ),
+    },
+    async (args: { classIri: string; atLayer?: string }) => {
+      const resp = await client.raw.getSchema(
+        create(GetSchemaRequestSchema, {
+          classIri: args.classIri,
+          atLayer: args.atLayer ?? "",
+        }),
+      );
+      if (!resp.success) {
+        return errorResult(`GetSchema failed: ${resp.error}`);
+      }
+      // jsonSchema is itself a JSON string — embed it as parsed JSON so the
+      // agent sees structure, not an escaped string.
+      const schema = JSON.parse(resp.jsonSchema);
+      const base = toJson(GetSchemaResponseSchema, resp) as Record<
+        string,
+        unknown
+      >;
+      return jsonResult({ ...base, jsonSchema: schema });
+    },
+  );
+
+  server.tool(
+    "eigenius_layer_topology",
+    "Walk the layer chain and return a graph (nodes + edges) summarising " +
+      "what each layer contributed. Use this to orient before deeper " +
+      "queries — see which classes / properties / institutions live where.",
+    {
+      rootLayer: z.string().optional().describe(
+        "Hex-encoded LayerId to root the walk at (defaults to the active top).",
+      ),
+      maxDepth: z.number().int().nonnegative().optional().describe(
+        "Maximum parent-pointer hops from `rootLayer`. 0 = unlimited.",
+      ),
+      includeResources: z.boolean().optional().describe(
+        "When true, emit a node per resource. When false (default), only " +
+          "Class / Property / Institution become nodes.",
+      ),
+    },
+    async (
+      args: {
+        rootLayer?: string;
+        maxDepth?: number;
+        includeResources?: boolean;
+      },
+    ) => {
+      const resp = await client.raw.layerTopology(
+        create(LayerTopologyRequestSchema, {
+          rootLayer: args.rootLayer ?? "",
+          maxDepth: args.maxDepth ?? 0,
+          includeResources: args.includeResources ?? false,
+        }),
+      );
+      return jsonResult(toJson(LayerTopologyResponseSchema, resp));
+    },
+  );
+
+  // ===========================================================================
+  // Mutate — commit-shaped operations.
+  // ===========================================================================
+
+  server.tool(
+    "eigenius_load",
+    "Load Eigon-JSON resources into the kernel as a new chain layer. " +
+      "The D41 commit pipeline runs structural validation, then either " +
+      "rejects on retroactive violations (`policy: 'reject'`, default) or " +
+      "iteratively tombstones violating lower-layer IRIs (`policy: " +
+      "'cascadeTombstone'`). The response surfaces per-layer outcomes — " +
+      "the user layer, optional audit-provenance sibling, and optional " +
+      "institution-classes child — each with its own branch-CAS outcome.",
+    {
+      json: z.string().describe(
+        "Eigon-JSON: a single resource (object) or a document (array of resources).",
+      ),
+      autoCommit: z.boolean().optional().describe(
+        "Commit after successful validation (default: true).",
+      ),
+      branch: z.string().optional().describe(
+        "Branch to commit into (defaults to 'main'). Must already exist.",
+      ),
+      policy: z.enum(["reject", "cascadeTombstone"]).optional().describe(
+        "Commit policy for retroactive validation (D41 §3.3). " +
+          "'reject' (default) fails the commit on any violation; " +
+          "'cascadeTombstone' iteratively tombstones violating lower-layer IRIs.",
+      ),
+      maxViolations: z.number().int().nonnegative().optional().describe(
+        "When policy='reject', cap on the number of ValidationError entries " +
+          "returned. 0 = kernel default (currently 100). The true count is " +
+          "always reported via `totalViolations`.",
+      ),
+      explicitTombstones: z.array(z.string()).optional().describe(
+        "IRIs the caller wants tombstoned as part of this commit (D41 §10.1).",
+      ),
+    },
+    async (
+      args: {
+        json: string;
+        autoCommit?: boolean;
+        branch?: string;
+        policy?: "reject" | "cascadeTombstone";
+        maxViolations?: number;
+        explicitTombstones?: string[];
+      },
+    ) => {
+      const policy: LoadPolicy | undefined = args.policy === "reject"
+        ? { kind: "reject", maxViolations: args.maxViolations }
+        : args.policy === "cascadeTombstone"
+        ? { kind: "cascadeTombstone" }
+        : undefined;
+
+      const resp = await client.load(args.json, {
+        autoCommit: args.autoCommit ?? true,
+        branch: args.branch,
+        policy,
+        explicitTombstones: args.explicitTombstones,
+      });
+      return jsonResult(toJson(LoadResponseSchema, resp));
+    },
+  );
+
+  server.tool(
+    "eigenius_validate_program",
+    "Type-check a program (Eigon-JSON) against the active layer chain " +
+      "without executing it. Returns the inferred program type and any " +
+      "validation errors.",
+    {
+      json: z.string().describe(
+        "Program resource as Eigon-JSON (single object or document).",
+      ),
+    },
+    async (args: { json: string }) => {
+      const resp = await client.validateProgram(args.json);
+      return jsonResult(toJson(ValidateProgramResponseSchema, resp));
+    },
+  );
+
+  server.tool(
+    "eigenius_run_program",
+    "Execute a program with input data, both supplied inline as " +
+      "Eigon-JSON. Returns the output resource (decoded from CBOR), the " +
+      "trace IRI, the task ID (when a persistent backend is attached), " +
+      "and any chain-resident output IRIs from FIBER reify steps.",
+    {
+      programJson: z.string().describe("Program resource as Eigon-JSON."),
+      inputJson: z.string().describe("Input resource as Eigon-JSON."),
+    },
+    async (args: { programJson: string; inputJson: string }) => {
+      const resp = await client.runProgram(args.programJson, args.inputJson);
+      const json = toJson(RunProgramResponseSchema, resp) as Record<
+        string,
+        unknown
+      >;
+      // `output` is base64-encoded CBOR in the proto-JSON shape. Decode
+      // for the agent so it sees the actual result resource, not bytes.
+      if (resp.success && resp.output.length > 0) {
+        try {
+          json.output = cborDecode(resp.output);
+        } catch (e) {
+          json.outputDecodeError = (e as Error).message;
+        }
+      }
+      return jsonResult(json);
+    },
+  );
+
+  server.tool(
+    "eigenius_run_program_by_iri",
+    "Execute a program already loaded into the chain, identified by IRI, " +
+      "against an input also in the chain. Avoids re-shipping bytes — the " +
+      "natural fit when the agent has just loaded both. Both reads can be " +
+      "pinned to a specific LayerId.",
+    {
+      programIri: z.string().describe("IRI of the program resource."),
+      inputIri: z.string().describe("IRI of the input resource."),
+      atLayer: z.string().optional().describe(
+        "Hex-encoded LayerId to pin both reads to (defaults to active top).",
+      ),
+      branch: z.string().optional().describe(
+        "Branch the trace layer commits into (defaults to 'main').",
+      ),
+    },
+    async (
+      args: {
+        programIri: string;
+        inputIri: string;
+        atLayer?: string;
+        branch?: string;
+      },
+    ) => {
+      const resp = await client.raw.runProgramByIri(
+        create(RunProgramByIriRequestSchema, {
+          programIri: args.programIri,
+          inputIri: args.inputIri,
+          atLayer: args.atLayer ?? "",
+          branch: args.branch ?? "",
+        }),
+      );
+      const json = toJson(RunProgramResponseSchema, resp) as Record<
+        string,
+        unknown
+      >;
+      if (resp.success && resp.output.length > 0) {
+        try {
+          json.output = cborDecode(resp.output);
+        } catch (e) {
+          json.outputDecodeError = (e as Error).message;
+        }
+      }
+      return jsonResult(json);
+    },
+  );
+
+  // ===========================================================================
+  // Observe — orientation and task state.
+  // ===========================================================================
+
+  server.tool(
+    "eigenius_health",
+    "Health check the kernel. Returns version, layer / resource counts, and " +
+      "the D21 resume-sweep state.",
+    {},
+    async () => {
+      const resp = await client.raw.health(create(HealthRequestSchema, {}));
+      return jsonResult(toJson(HealthResponseSchema, resp));
+    },
+  );
+
+  server.tool(
+    "eigenius_list_tasks",
+    "List every D21 task in the session — running, suspended, completed, " +
+      "or failed. Empty when no persistent backend is attached.",
+    {},
+    async () => {
+      const resp = await client.raw.listTasks(
+        create(ListTasksRequestSchema, {}),
+      );
+      return jsonResult(toJson(ListTasksResponseSchema, resp));
+    },
+  );
+
+  server.tool(
+    "eigenius_get_task_status",
+    "Look up a specific task's status, pinned LayerId, and result-layer " +
+      "head (when completed).",
+    {
+      taskId: z.string().describe("Task UUID."),
+    },
+    async (args: { taskId: string }) => {
+      const resp = await client.raw.getTaskStatus(
+        create(GetTaskStatusRequestSchema, { taskId: args.taskId }),
+      );
+      return jsonResult(toJson(GetTaskStatusResponseSchema, resp));
     },
   );
 
@@ -188,12 +470,97 @@ export function createMcpServer(client: KernelClient): McpServer {
 }
 
 /**
- * Start the MCP server with stdio transport (for local integration).
+ * Start the MCP server with stdio transport. The standard wiring for
+ * Claude Desktop / similar local agent hosts: the host launches the
+ * orchestrator process with stdin/stdout piped, and the MCP protocol
+ * runs over those two FDs.
  */
 export async function startStdioServer(server: McpServer): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   log.info(operation.MCP_SERVER_START, "MCP server connected", {
     transport: "stdio",
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const IS_A = "urn:eigenius:core:is_a";
+const RESULT_SET_CLASS = "urn:eigenius:query:ResultSet";
+const ROWS_PROP = "urn:eigenius:query:rows";
+
+/**
+ * Walk an Eigon-CBOR query document and return each row as a decoded JS
+ * object. Mirrors `extractRowBytes` in `client/kernel_client.ts` but
+ * returns decoded values rather than re-encoded bytes — MCP consumers
+ * want JSON, not CBOR.
+ */
+function decodeQueryRows(documentBytes: Uint8Array): unknown[] {
+  // deno-lint-ignore no-explicit-any
+  const decoded: any = cborDecode(documentBytes);
+  const resources = Array.isArray(decoded) ? decoded : [decoded];
+  const resultSet = resources.find((r) =>
+    r && Array.isArray(r[IS_A]) && r[IS_A].includes(RESULT_SET_CLASS)
+  );
+  if (!resultSet) return [];
+  const rowsField = resultSet[ROWS_PROP];
+  if (!Array.isArray(rowsField)) return [];
+  return rowsField.map((entry) => {
+    // Rows are either embedded resource objects or IRI references; in the
+    // EigenQL result document they're always embedded.
+    if (typeof entry === "object" && entry !== null) return entry;
+    return { ref: entry };
+  });
+}
+
+/** Wrap a value as a single text-content JSON response. */
+function jsonResult(value: unknown) {
+  return {
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify(value, replaceBigint, 2),
+    }],
+  };
+}
+
+/** Wrap an error message as an MCP `isError: true` response. */
+function errorResult(message: string) {
+  return {
+    content: [{
+      type: "text" as const,
+      text: message,
+    }],
+    isError: true,
+  };
+}
+
+/** JSON.stringify replacer that handles bigint (proto uint64 / int64). */
+function replaceBigint(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+/**
+ * Best-effort `toJson` wrapper for embedded sub-messages we don't have
+ * a schema import handy for (e.g. `MergeInfo` nested inside a
+ * QueryResponse — toJson at the parent level handles it, but we want
+ * to project it standalone for the Query tool). Falls back to a manual
+ * object snapshot.
+ */
+// deno-lint-ignore no-explicit-any
+function toJsonSafe(_label: string, message: any): unknown {
+  if (!message) return null;
+  // The buf-generated message has typeName-keyed serialiser metadata
+  // we'd need to look up. Cheaper to do a plain spread — the enum
+  // numeric values won't be human-readable, but Outcome semantics are
+  // documented in proto comments and the agent can match by number.
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(message)) {
+    if (typeof v === "bigint") out[k] = v.toString();
+    else out[k] = v;
+  }
+  return out;
 }

--- a/orchestration/src/mcp_main.ts
+++ b/orchestration/src/mcp_main.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 The Eigenius Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * MCP stdio entry point.
+ *
+ * Runs the Eigenius MCP server over stdin / stdout — the standard wiring
+ * for Claude Desktop, IDE-integrated agents, and `mcp-cli`. Connects to
+ * an already-running kernel at `EIGENIUS_KERNEL_ENDPOINT` (no kernel is
+ * spawned by this process).
+ *
+ * Example Claude Desktop config:
+ *
+ *     {
+ *       "mcpServers": {
+ *         "eigenius": {
+ *           "command": "deno",
+ *           "args": ["task", "mcp"],
+ *           "cwd": "/path/to/eigenius/orchestration",
+ *           "env": { "EIGENIUS_KERNEL_ENDPOINT": "http://localhost:50051" }
+ *         }
+ *       }
+ *     }
+ *
+ * The orchestrator's main HTTP service (`src/main.ts`) is independent —
+ * the MCP entry point connects directly to the kernel and does not need
+ * the orchestrator's component / WASM / substrate plumbing.
+ */
+
+import { KernelClient } from "./client/kernel_client.ts";
+import { createMcpServer, startStdioServer } from "./mcp/server.ts";
+import * as log from "./observability/mod.ts";
+
+const KERNEL_ENDPOINT = Deno.env.get("EIGENIUS_KERNEL_ENDPOINT") ??
+  "http://localhost:50051";
+
+async function main() {
+  log.init();
+
+  const client = new KernelClient(KERNEL_ENDPOINT);
+  const server = createMcpServer(client);
+  await startStdioServer(server);
+}
+
+await main();

--- a/orchestration/src/server/mod.ts
+++ b/orchestration/src/server/mod.ts
@@ -39,10 +39,11 @@ import { createNotebookStaticHandler } from "./notebook_static.ts";
 /**
  * Start the orchestrator server.
  *
- * Listens on `port` and serves three Connect surfaces plus a health endpoint:
+ * Listens on `port` and serves the Connect surfaces plus a health endpoint:
  * - gRPC: ComponentExecutor.Execute       (kernel → orchestrator IO dispatch)
  * - gRPC: NotebookService.LayerTopology   (browser → orchestrator → kernel)
  * - HTTP: GET /health
+ * - HTTP: POST /mcp   (when `mcpHandler` is supplied — MCP Streamable HTTP)
  *
  * The browser also reaches the existing EigeniusKernel surface (Inspect,
  * Query, Load, RunProgram, etc.) via the orchestrator's kernel client;
@@ -55,6 +56,7 @@ export function startServer(
   port: number,
   wasm?: ComponentExecutorDeps["wasm"],
   substrate?: ComponentExecutorDeps["substrate"],
+  mcpHandler?: (req: Request) => Promise<Response>,
 ): void {
   const router = createConnectRouter();
   registerComponentExecutor(router, { registry, wasm, substrate });
@@ -89,6 +91,15 @@ export function startServer(
       );
     }
 
+    // MCP Streamable HTTP endpoint (when wired up). The transport
+    // accepts POST (client → server messages), GET (SSE stream — unused
+    // in our stateless+JSON mode but still routed), and DELETE (session
+    // termination). Handing the full Web Request to the SDK keeps the
+    // protocol shape entirely on the SDK side.
+    if (mcpHandler && url.pathname === "/mcp") {
+      return await mcpHandler(req);
+    }
+
     // Notebook SPA static files (when configured).
     if (notebookStatic) {
       const staticResp = await notebookStatic.tryServe(req);
@@ -121,6 +132,7 @@ export function startServer(
     ],
     health_endpoint: "/health",
     notebook_static: notebookStatic ? notebookStaticDir : null,
+    mcp_endpoint: mcpHandler ? "/mcp" : null,
   });
 }
 

--- a/orchestration/tests/mcp_test.ts
+++ b/orchestration/tests/mcp_test.ts
@@ -183,12 +183,14 @@ Deno.test("HTTP handler: tools carrying required arguments declare them", async 
   ]);
 
   // No-args tools should not declare a required array (or it should be empty).
-  for (const noArgs of [
-    "eigenius_health",
-    "eigenius_list_branches",
-    "eigenius_list_tags",
-    "eigenius_list_tasks",
-  ]) {
+  for (
+    const noArgs of [
+      "eigenius_health",
+      "eigenius_list_branches",
+      "eigenius_list_tags",
+      "eigenius_list_tasks",
+    ]
+  ) {
     const req = byName[noArgs].inputSchema.required;
     if (req !== undefined) assertEquals(req, []);
   }

--- a/orchestration/tests/mcp_test.ts
+++ b/orchestration/tests/mcp_test.ts
@@ -1,0 +1,316 @@
+// Copyright 2026 The Eigenius Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Unit tests for the MCP server + HTTP transport.
+ *
+ * These tests run entirely in-process: the orchestrator's `KernelClient`
+ * is replaced with a stub that returns canned proto responses, and the
+ * HTTP handler is driven via synthetic `Request` objects (no socket).
+ * No kernel subprocess, no network — runs in milliseconds.
+ *
+ * What this catches:
+ *  - A tool getting accidentally dropped during a refactor
+ *    (`tools/list` count regression).
+ *  - The implicit-any handler signature bug that broke compile in the
+ *    initial rewrite.
+ *  - The "stateless transport cannot be reused" regression
+ *    (sequential-requests test).
+ *  - Kernel-side errors silently succeeding (the isError contract).
+ *
+ * What this deliberately does NOT cover:
+ *  - End-to-end against a real kernel (Layer 2 — `topology_e2e_test.ts`
+ *    pattern; spawn kernel + orchestrator subprocesses, POST over the
+ *    network).
+ *  - Per-tool argument validation against the kernel's actual proto
+ *    contract (those are caught by `deno check` + the e2e layer).
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { create } from "@bufbuild/protobuf";
+import { HealthResponseSchema } from "../src/gen/eigenius_pb.ts";
+import { createMcpServer } from "../src/mcp/server.ts";
+import { createMcpHttpHandler } from "../src/mcp/http.ts";
+import type { KernelClient } from "../src/client/kernel_client.ts";
+
+// ---------------------------------------------------------------------------
+// Stub KernelClient
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a KernelClient-shaped stub. Only the methods the tests below
+ * actually invoke need to be supplied — `tools/list` doesn't call any
+ * RPCs, so an empty `raw` works for that. `tools/call <tool>` requires
+ * the corresponding `raw.<rpc>` to be present.
+ */
+// deno-lint-ignore no-explicit-any
+type StubRaw = Record<string, (req?: unknown) => Promise<any>>;
+
+function makeStubClient(raw: StubRaw = {}): KernelClient {
+  return { raw } as unknown as KernelClient;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP request helper
+// ---------------------------------------------------------------------------
+
+async function rpcCall(
+  handler: (req: Request) => Promise<Response>,
+  body: unknown,
+): Promise<{
+  status: number;
+  // deno-lint-ignore no-explicit-any
+  body: any;
+}> {
+  const req = new Request("http://test/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+  const res = await handler(req);
+  return { status: res.status, body: await res.json() };
+}
+
+// ---------------------------------------------------------------------------
+// The canonical tool inventory. If you add or remove a tool in
+// `mcp/server.ts`, update this list — the `tools/list` test will fail
+// otherwise. That failure is on purpose; a silent tool-count change is
+// exactly what these tests exist to surface.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_TOOLS = [
+  "eigenius_query",
+  "eigenius_inspect",
+  "eigenius_list_branches",
+  "eigenius_list_tags",
+  "eigenius_list_institutions",
+  "eigenius_get_schema",
+  "eigenius_layer_topology",
+  "eigenius_load",
+  "eigenius_validate_program",
+  "eigenius_run_program",
+  "eigenius_run_program_by_iri",
+  "eigenius_health",
+  "eigenius_list_tasks",
+  "eigenius_get_task_status",
+].sort();
+
+// ===========================================================================
+// Server construction
+// ===========================================================================
+
+Deno.test("createMcpServer instantiates without I/O", () => {
+  const server = createMcpServer(makeStubClient());
+  assertExists(server);
+});
+
+// ===========================================================================
+// tools/list
+// ===========================================================================
+
+Deno.test("HTTP handler: tools/list returns exactly the expected 14 tools", async () => {
+  const handler = createMcpHttpHandler(() => createMcpServer(makeStubClient()));
+  const { status, body } = await rpcCall(handler, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  });
+  assertEquals(status, 200);
+  assertExists(body.result, `no result in response: ${JSON.stringify(body)}`);
+  const names = body.result.tools
+    .map((t: { name: string }) => t.name)
+    .sort();
+  assertEquals(names, EXPECTED_TOOLS);
+});
+
+Deno.test("HTTP handler: every tool advertises an object-typed inputSchema", async () => {
+  const handler = createMcpHttpHandler(() => createMcpServer(makeStubClient()));
+  const { body } = await rpcCall(handler, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  });
+  for (const t of body.result.tools) {
+    assertExists(t.inputSchema, `tool ${t.name} missing inputSchema`);
+    assertEquals(
+      t.inputSchema.type,
+      "object",
+      `tool ${t.name} inputSchema.type !== "object"`,
+    );
+  }
+});
+
+Deno.test("HTTP handler: tools carrying required arguments declare them", async () => {
+  const handler = createMcpHttpHandler(() => createMcpServer(makeStubClient()));
+  const { body } = await rpcCall(handler, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  });
+  // deno-lint-ignore no-explicit-any
+  const byName: Record<string, any> = {};
+  for (const t of body.result.tools) byName[t.name] = t;
+
+  // Sanity-check a few tools whose required-field set we care about.
+  // Catches schema regressions like an optional field becoming required
+  // or vice versa.
+  assertEquals(byName.eigenius_query.inputSchema.required, ["eigenql"]);
+  assertEquals(byName.eigenius_inspect.inputSchema.required, ["iri"]);
+  assertEquals(byName.eigenius_load.inputSchema.required, ["json"]);
+  assertEquals(byName.eigenius_run_program.inputSchema.required, [
+    "programJson",
+    "inputJson",
+  ]);
+  assertEquals(byName.eigenius_get_task_status.inputSchema.required, [
+    "taskId",
+  ]);
+
+  // No-args tools should not declare a required array (or it should be empty).
+  for (const noArgs of [
+    "eigenius_health",
+    "eigenius_list_branches",
+    "eigenius_list_tags",
+    "eigenius_list_tasks",
+  ]) {
+    const req = byName[noArgs].inputSchema.required;
+    if (req !== undefined) assertEquals(req, []);
+  }
+});
+
+// ===========================================================================
+// tools/call — happy path
+// ===========================================================================
+
+Deno.test("HTTP handler: tools/call eigenius_health surfaces the kernel response", async () => {
+  const client = makeStubClient({
+    health: () =>
+      Promise.resolve(create(HealthResponseSchema, {
+        healthy: true,
+        version: "test-1.0",
+        layerCount: 7n,
+        resourceCount: 42n,
+      })),
+  });
+  const handler = createMcpHttpHandler(() => createMcpServer(client));
+
+  const { status, body } = await rpcCall(handler, {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "eigenius_health", arguments: {} },
+  });
+  assertEquals(status, 200);
+  assertExists(body.result?.content?.[0]?.text);
+  const parsed = JSON.parse(body.result.content[0].text);
+  assertEquals(parsed.healthy, true);
+  assertEquals(parsed.version, "test-1.0");
+  // uint64 fields come through `toJson` as decimal strings.
+  assertEquals(parsed.layerCount, "7");
+  assertEquals(parsed.resourceCount, "42");
+});
+
+// ===========================================================================
+// tools/call — kernel rejection propagates as isError
+// ===========================================================================
+
+Deno.test("HTTP handler: tools/call surfaces kernel rejections as isError", async () => {
+  const client = makeStubClient({
+    listBranches: () =>
+      Promise.reject(
+        new Error("branch operations require a persistent backend"),
+      ),
+  });
+  const handler = createMcpHttpHandler(() => createMcpServer(client));
+
+  const { status, body } = await rpcCall(handler, {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "eigenius_list_branches", arguments: {} },
+  });
+  assertEquals(status, 200);
+  // The SDK wraps a thrown handler error as `isError: true` content
+  // (CallToolResult shape) rather than a JSON-RPC error envelope.
+  // That's the contract we depend on — if a future SDK switches to
+  // JSON-RPC errors for handler throws, the assertion fires.
+  assertEquals(body.result?.isError, true);
+  const text = body.result.content[0].text;
+  assert(
+    typeof text === "string" && text.length > 0,
+    `expected non-empty error text, got: ${JSON.stringify(text)}`,
+  );
+});
+
+// ===========================================================================
+// Per-request transport lifecycle
+// ===========================================================================
+
+Deno.test(
+  "HTTP handler: sequential calls succeed (per-request fresh transport)",
+  async () => {
+    // The SDK's stateless transport must be reconstructed per request —
+    // reusing one across requests raises
+    //   "Stateless transport cannot be reused across requests."
+    // (See `mcp/http.ts` for the per-request `buildServer()` pattern.)
+    // This test pins that contract: three back-to-back calls must all
+    // succeed against a single handler instance.
+    const handler = createMcpHttpHandler(() =>
+      createMcpServer(makeStubClient({
+        health: () =>
+          Promise.resolve(create(HealthResponseSchema, { healthy: true })),
+      }))
+    );
+
+    for (let i = 0; i < 3; i++) {
+      const { status, body } = await rpcCall(handler, {
+        jsonrpc: "2.0",
+        id: 100 + i,
+        method: "tools/call",
+        params: { name: "eigenius_health", arguments: {} },
+      });
+      assertEquals(status, 200, `request ${i} status`);
+      assertExists(body.result, `request ${i} had no result`);
+      assertEquals(body.result.isError, undefined, `request ${i} was error`);
+    }
+  },
+);
+
+// ===========================================================================
+// tools/call — unknown tool
+// ===========================================================================
+
+Deno.test("HTTP handler: tools/call with unknown tool returns an error", async () => {
+  const handler = createMcpHttpHandler(() => createMcpServer(makeStubClient()));
+
+  const { body } = await rpcCall(handler, {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: { name: "eigenius_nonexistent", arguments: {} },
+  });
+  // The SDK may report this as a JSON-RPC error or as `isError: true`
+  // content — accept either, but reject silent success.
+  const isJsonRpcError = body.error !== undefined;
+  const isContentError = body.result?.isError === true;
+  assert(
+    isJsonRpcError || isContentError,
+    `expected error response, got: ${JSON.stringify(body)}`,
+  );
+});


### PR DESCRIPTION
Rebuild mcp/server.ts against the current proto surface (14 tools across
explore/mutate/observe; replaces the stale 4-tool dead code). Mount
WebStandardStreamableHTTPServerTransport at /mcp on the orchestrator's
existing port so clients connect via http://localhost:8080/mcp without a
host-side subprocess; keep `deno task mcp` (stdio) for kernel-on-host dev.
Ship .claude/skills/eigenius.md, README + platform §7.7 docs, and 8 unit
tests pinning tool inventory, schema shape, and the per-request
stateless-transport lifecycle the SDK requires.
